### PR TITLE
fix(docs): adjust links to render

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -42,7 +42,7 @@ AstroNvim is an aesthetic and feature-rich neovim config that is extensible and 
 
 :::info
 
-<sup id="2">[2]</sup> When using default theme: For MacOS, the default terminal does not have true color support. You will need to use [iTerm2](https://iterm2.com/), [Kitty](https://sw.kovidgoyal.net/kitty/), [WezTerm](https://wezfurlong.org/wezterm/), or another [terminal emulator](https://gist.github.com/XVilka/8346728#terminal-emulators) that has true color support.
+<sup id="2">[2]</sup> When using default theme: For MacOS, the default terminal does not have true color support. You will need to use <a href="https://iterm2.com/">iTerm2</a>, <a href="https://sw.kovidgoyal.net/kitty/">Kitty</a>, <a href="https://wezfurlong.org/wezterm/">WezTerm</a>, or another <a href="https://github.com/termstandard/colors">terminal emulator</a> that has true color support.
 
 :::
 


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->
Closes #109

## 📑 Description

<!-- Add a brief description of the pr -->

- Fix link rendering for home page
- Fix link location for terminal emulators


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

<img width="1206" alt="image" src="https://github.com/AstroNvim/docs/assets/45884264/960eb8a8-934b-4a54-92c0-03128b61f1e7">

See: Fixed renders, link to terminal emulator goes to new repo
