### PR TITLE
fix(mappings): correct prev completion mappings

### DIFF
--- a/src/content/docs/mappings.mdx
+++ b/src/content/docs/mappings.mdx
@@ -63,19 +63,19 @@ AstroNvim generally relies on `<Leader>` driven mappings, which is default set t
 
 ## Completion
 
-| Action                      | Mappings                              |
-| --------------------------- | ------------------------------------- |
-| Open completion menu        | `Ctrl + Space`                        |
-| Select completion           | `Enter`                               |
-| Next snippet location       | `Tab`                                 |
-| Previous snippet location   | `Shift + Tab`                         |
-| Next completion             | `Down`, `Ctrl + n`, `Ctrl + j`, `Tab` |
-| Previous completion         | `Down`, `Ctrl + n`, `Ctrl + k`, `Tab` |
-| Next snippet location       | `Tab`                                 |
-| Previous snippet location   | `Shift + Tab`                         |
-| Cancel completion           | `Ctrl + e`                            |
-| Scroll up completion docs   | `Ctrl + u`                            |
-| Scroll down completion docs | `Ctrl + d`                            |
+| Action                      | Mappings                                    |
+| --------------------------- | ------------------------------------------- |
+| Open completion menu        | `Ctrl + Space`                              |
+| Select completion           | `Enter`                                     |
+| Next snippet location       | `Tab`                                       |
+| Previous snippet location   | `Shift + Tab`                               |
+| Next completion             | `Down`, `Ctrl + n`, `Ctrl + j`, `Tab`       |
+| Previous completion         | `Up`, `Ctrl + p`, `Ctrl + k`, `Shift + Tab` |
+| Next snippet location       | `Tab`                                       |
+| Previous snippet location   | `Shift + Tab`                               |
+| Cancel completion           | `Ctrl + e`                                  |
+| Scroll up completion docs   | `Ctrl + u`                                  |
+| Scroll down completion docs | `Ctrl + d`                                  |
 
 ## Neo-Tree
 


### PR DESCRIPTION
## 📑 Description

Fix the mappings listed for `Previous completion`.