### PR TITLE
fix(reference): remove unnecessary backtick from the clone commands

### DIFF
--- a/src/content/docs/reference/alt_install.mdx
+++ b/src/content/docs/reference/alt_install.mdx
@@ -21,7 +21,7 @@ nvim --headless +q
 1. Clone your configuration to `~/.config/nvim`, example using the AstroNvim template:
 
    ```sh
-   git clone https://github.com/AstroNvim/template ~/.config/nvim`
+   git clone https://github.com/AstroNvim/template ~/.config/nvim
    ```
 
 2. Run the headless installation
@@ -41,7 +41,7 @@ Neovim v0.9 introduced a great new environment variable called `NVIM_APPNAME` wh
 1. Clone your configuration to `~/.config/astronvim`, example using the AstroNvim template:
 
    ```sh
-   git clone https://github.com/AstroNvim/template ~/.config/astronvim`
+   git clone https://github.com/AstroNvim/template ~/.config/astronvim
    ```
 
 2. Start the editor with `NVIM_APPNAME` environment variable set to `astronvim`


### PR DESCRIPTION
## 📑 Description

Fixes typo at alt_install.mdx
