### PR TITLE
fix(mappings): remove repeated snippet nav mappings

### DIFF
--- a/src/content/docs/mappings.mdx
+++ b/src/content/docs/mappings.mdx
@@ -71,8 +71,6 @@ AstroNvim generally relies on `<Leader>` driven mappings, which is default set t
 | Previous snippet location   | `Shift + Tab`                               |
 | Next completion             | `Down`, `Ctrl + n`, `Ctrl + j`, `Tab`       |
 | Previous completion         | `Up`, `Ctrl + p`, `Ctrl + k`, `Shift + Tab` |
-| Next snippet location       | `Tab`                                       |
-| Previous snippet location   | `Shift + Tab`                               |
 | Cancel completion           | `Ctrl + e`                                  |
 | Scroll up completion docs   | `Ctrl + u`                                  |
 | Scroll down completion docs | `Ctrl + d`                                  |


### PR DESCRIPTION
## 📑 Description

This removes the repeated mappings for `Next snippet location` and `Previous snippet location` leaving the ones on lines 70-71.