### PR TITLE
Fix typo in user config path

### DIFF
--- a/src/content/docs/configuration/manage_user_config.mdx
+++ b/src/content/docs/configuration/manage_user_config.mdx
@@ -18,7 +18,7 @@ AstroNvim is installed with the `lazy.nvim` plugin manager just like any other p
 
 1. Use our [AstroNvim/template](https://github.com/AstroNvim/template) GitHub template to make a new personal user configuration repository. For these steps we will assume your repo is `username/astronvim_config`
 
-2. Clone your empty new repository to your `~/.config/nvim/lua` folder
+2. Clone your empty new repository to your `~/.config/nvim` folder
 
    ```sh
    git clone https://github.com/username/astronvim_config.git ~/.config/nvim


### PR DESCRIPTION

## 📑 Description

The docs indicates `~/.config/nvim/lua` as the path to clone the user config into. But it seems the correct path is `~/.config/nvim`.
