### PR TITLE
docs: fix example with open alpha on last buffer close

### DIFF
--- a/src/content/docs/recipes/alpha.mdx
+++ b/src/content/docs/recipes/alpha.mdx
@@ -54,7 +54,7 @@ return {
             if
               require("astrocore").is_available("alpha-nvim") and not bufs[2]
             then
-              require("alpha").start(true)
+              require("alpha").start()
             end
           end,
           desc = "Close buffer",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
With `.start(true)` Alpha dashboard never get opened on last buffer close.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
