### PR TITLE
doc: update the update command

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -168,7 +168,7 @@ docker run -w /root -it --rm alpine:edge sh -uelic '
 
 - **Update Mason packages and plugins**
 
-  Run `:AstroUpdatePackages` (`<Leader>pa`) to update both Neovim plugins and Mason packages
+  Run `:AstroUpdate` (`<Leader>pa`) to update both Neovim plugins and Mason packages
 
 - **Reload AstroNvim** (_EXPERIMENTAL_)
 


### PR DESCRIPTION
## 📑 Description

it looks like with the release of 4.0, AstroUpdatePackages was removed and AstroUpdate does the same thing (it calls astrocore and updates everything)
