### PR TITLE
fix(mappings): fix typo

### DIFF
--- a/src/content/docs/recipes/mappings.mdx
+++ b/src/content/docs/recipes/mappings.mdx
@@ -85,7 +85,7 @@ return {
 
 :::
 
-Telescope proivdes functionality for using the picker for tasks such as getting references and symbols. This can be easily enabled through AstroLSP. Here is an example specification that can be added to your plugins:
+Telescope provides functionality for using the picker for tasks such as getting references and symbols. This can be easily enabled through AstroLSP. Here is an example specification that can be added to your plugins:
 
 ```lua title="lua/plugins/telescope_lsp_mappings.lua"
 return {


### PR DESCRIPTION
## 📑 Description

This fixes a small typo in this [part](https://docs.astronvim.com/recipes/mappings/#enable-telescope-lsp-mappings) of the docs.