### PR TITLE
Fix: invalid mapping for floating terminal

### DIFF
--- a/src/content/docs/mappings.mdx
+++ b/src/content/docs/mappings.mdx
@@ -211,8 +211,8 @@ AstroNvim generally relies on `<Leader>` driven mappings, which is default set t
 
 | Action                   | Mappings                |
 | ------------------------ | ----------------------- |
-| Open Floating Terminal   | `Leader + tf` or `<F7>` |
-| Open Horizontal Terminal | `Leader + th`           |
+| Open Floating Terminal   | `Leader + tf`           |
+| Open Horizontal Terminal | `Leader + th` or `<F7>` |
 | Open Vertical Terminal   | `Leader + tv`           |
 | Open Toggle Lazygit      | `Leader + tl`           |
 | Open Toggle node         | `Leader + tn`           |


### PR DESCRIPTION
## 📑 Description

As of AstroNvim v4.23.0, the default direction for terminals was changed to `horizontal`. This PR updates the `mappings` page of the docs with the new information.
