### PR TITLE
docs: add section to adjust cmp label and menu length

### DIFF
--- a/src/content/docs/recipes/cmp.mdx
+++ b/src/content/docs/recipes/cmp.mdx
@@ -153,22 +153,20 @@ return {
   "hrsh7th/nvim-cmp",
   opts = function(_, opts)
     local astrocore, astroui = require "astrocore", require "astroui"
+    local function truncate(str, len)
+      if not str then return end
+      local truncated = vim.fn.strcharpart(str, 0, len)
+      return truncated == str and str or truncated .. astroui.get_icon "Ellipsis"
+    end
+
     if not opts.formatting then opts.formatting = {} end
     opts.formatting.format = astrocore.patch_func(opts.formatting.format, function(format, ...)
       -- get item from original formatting function
       local vim_item = format(...)
 
-      -- truncate label to maximum of 25% of the window
-      local label = vim_item.abbr
-      local truncated_label = vim.fn.strcharpart(label, 0, math.floor(0.25 * vim.o.columns))
-      if truncated_label ~= label then vim_item.abbr = truncated_label .. astroui.get_icon "Ellipsis" end
-
-      -- truncate menu to maximum of 25% of the window
-      if vim_item.menu then
-        local menu = vim_item.menu
-        local truncated_menu = vim.fn.strcharpart(menu, 0, math.floor(0.25 * vim.o.columns))
-        if truncated_menu ~= menu then vim_item.menu = truncated_menu .. astroui.get_icon "Ellipsis" end
-      end
+      -- truncate text fields to maximum of 25% of the window
+      vim_item.abbr = truncate(vim_item.abbr, math.floor(0.25 * vim.o.columns))
+      vim_item.menu = truncate(vim_item.menu, math.floor(0.25 * vim.o.columns))
 
       return vim_item
     end)

--- a/src/content/docs/recipes/cmp.mdx
+++ b/src/content/docs/recipes/cmp.mdx
@@ -143,3 +143,32 @@ return { -- override nvim-cmp plugin
   end,
 }
 ```
+
+### Limit Label and Menu Item Length
+
+To limit the label and menu item length and prevent the documentation window from getting too small, you can use the following configuration:
+
+```lua title="lua/plugins/cmp.lua"
+return {
+  "hrsh7th/nvim-cmp",
+  opts = function(_, opts)
+    local astrocore, astroui = require "astrocore", require "astroui"
+    if not opts.formatting then opts.formatting = {} end
+    opts.formatting.format = astrocore.patch_func(opts.formatting.format, function(format, ...)
+      -- get item from original formatting function
+      local vim_item = format(...)
+
+      -- truncate label to maximum of 25% of the window
+      local label = vim_item.abbr
+      local truncated_label = vim.fn.strcharpart(label, 0, math.floor(0.25 * vim.o.columns))
+      if truncated_label ~= label then vim_item.abbr = truncated_label .. astroui.get_icon "Ellipsis" end
+
+      -- truncate menu to maximum of 25% of the window
+      local menu = vim_item.menu or ""
+      local truncated_menu = vim.fn.strcharpart(menu, 0, math.floor(0.25 * vim.o.columns))
+      if truncated_menu ~= menu then vim_item.menu = truncated_menu .. astroui.get_icon "Ellipsis" end
+
+      return vim_item
+    end)
+  end,
+}

--- a/src/content/docs/recipes/cmp.mdx
+++ b/src/content/docs/recipes/cmp.mdx
@@ -164,9 +164,11 @@ return {
       if truncated_label ~= label then vim_item.abbr = truncated_label .. astroui.get_icon "Ellipsis" end
 
       -- truncate menu to maximum of 25% of the window
-      local menu = vim_item.menu or ""
-      local truncated_menu = vim.fn.strcharpart(menu, 0, math.floor(0.25 * vim.o.columns))
-      if truncated_menu ~= menu then vim_item.menu = truncated_menu .. astroui.get_icon "Ellipsis" end
+      if vim_item.menu then
+        local menu = vim_item.menu
+        local truncated_menu = vim.fn.strcharpart(menu, 0, math.floor(0.25 * vim.o.columns))
+        if truncated_menu ~= menu then vim_item.menu = truncated_menu .. astroui.get_icon "Ellipsis" end
+      end
 
       return vim_item
     end)

--- a/src/content/docs/recipes/cmp.mdx
+++ b/src/content/docs/recipes/cmp.mdx
@@ -174,3 +174,4 @@ return {
     end)
   end,
 }
+```


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
This adds a section on how to adjust cmp to limit it's size. To solve an issue like this: https://github.com/hrsh7th/nvim-cmp/issues/1154#issuecomment-1872926479

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
