### PR TITLE
Replace `rust-tools` with `rustaceanvim`

### DIFF
--- a/src/content/docs/recipes/advanced_lsp.mdx
+++ b/src/content/docs/recipes/advanced_lsp.mdx
@@ -566,7 +566,7 @@ return {
 }
 ```
 
-### Rust ([rust-tools.nvim](https://github.com/simrat39/rust-tools.nvim))
+### Rust ([rustaceanvim](https://github.com/mrcjkb/rustaceanvim))
 
 :::tip
 
@@ -581,19 +581,18 @@ return {
 
 :::
 
-```lua title="lua/plugins/rust-tools.lua"
+```lua title="lua/plugins/rustaceanvim.lua"
 return {
-  { "simrat39/rust-tools.nvim", lazy = true }, -- add lsp plugin
+  {
+    'mrcjkb/rustaceanvim', -- add lsp plugin
+    version = '^5',
+    lazy = false, -- This plugin is already lazy
+  },
   {
     "AstroNvim/astrolsp",
     ---@type AstroLSPOpts
     opts = {
-      setup_handlers = {
-        -- add custom handler
-        rust_analyzer = function(_, opts)
-          require("rust-tools").setup({ server = opts })
-        end,
-      },
+      handlers = { rust_analyzer = false }, -- Let rustaceanvim setup `rust_analyzer`
     },
   },
   {

--- a/src/content/docs/recipes/advanced_lsp.mdx
+++ b/src/content/docs/recipes/advanced_lsp.mdx
@@ -587,6 +587,28 @@ return {
     'mrcjkb/rustaceanvim', -- add lsp plugin
     version = '^5',
     lazy = false, -- This plugin is already lazy
+    opts = function(_, opts)
+      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
+      local astrolsp_opts = (astrolsp_avail and astrolsp.lsp_opts "rust_analyzer") or {}
+      local server = {
+        ---@type table | (fun(project_root:string|nil, default_settings: table|nil):table) -- The rust-analyzer settings or a function that creates them.
+        settings = function(project_root, default_settings)
+          local astrolsp_settings = astrolsp_opts.settings or {}
+
+          local merge_table = require("astrocore").extend_tbl(default_settings or {}, astrolsp_settings)
+          local ra = require "rustaceanvim.config.server"
+          -- load_rust_analyzer_settings merges any found settings with the passed in default settings table and then returns that table
+          return ra.load_rust_analyzer_settings(project_root, {
+            settings_file_pattern = "rust-analyzer.json",
+            default_settings = merge_table,
+          })
+        end,
+      }
+      return { server = require("astrocore").extend_tbl(astrolsp_opts, server) }
+    end,
+    -- configure `rustaceanvim` by setting the `vim.g.rustaceanvim` variable
+    config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
+
   },
   {
     "AstroNvim/astrolsp",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Replace [rust-tools](https://github.com/simrat39/rust-tools.nvim) with [rustaceanvim](https://github.com/mrcjkb/rustaceanvim).

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

The `rust-tools` repo is now archived. `rustaceanvim` is a maintained fork of `rust-tools`.
The [Astrocommunity Rust language pack](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/pack/rust) has also migrated to `rustaceanvim`.
