### PR TITLE
fix(ai): blink.cmp should be default completion plugin

### DIFF
--- a/src/content/docs/recipes/ai.mdx
+++ b/src/content/docs/recipes/ai.mdx
@@ -26,7 +26,7 @@ These configurations set up the completion engines to look for a function stored
 
 #### [blink.cmp](https://github.com/Saghen/blink.cmp) Integration
 
-[blink.cmp](https://github.com/Saghen/blink.cmp) is another popular completion plugin. This configures the `<Tab>` key as described above:
+By default AstroNvim comes with [blink.cmp](https://github.com/Saghen/blink.cmp) for completion. This modifies the default configuration to set up the `<Tab>` key as described above:
 
 ```lua title="lua/plugins/cmp_ai.lua"
 return {
@@ -52,7 +52,7 @@ return {
 
 #### [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) Integration
 
-By default AstroNvim comes with [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp) for completion. This modifies the default configuration to set up the `<Tab>` key as described above:
+[`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp) is another popular completion plugin. This configures the `<Tab>` key as described above:
 
 ```lua title="lua/plugins/cmp_ai.lua"
 return {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

In the AI guide, is mentions that `nvim-cmp` is the default completion plugin, but in the "Customize cmp completion" guide it says `blink.cmp` is the default one. This fix updates the AI doc to match the completion one.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
